### PR TITLE
Fix: Unbounded Cache Vulnerability

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ const PORT = process.env.PORT || 8000;
 const server = new ApolloServer({
     typeDefs,
     resolvers,
+    cache: 'bounded',
     context: ({ req }) => ({ req })
 });
 


### PR DESCRIPTION
The default config in Apollo Server v3 exposes the server to denial of service attacks via memory exhaustion.

> ⚠️ New in Apollo Server 3.9: We strongly recommend that all users pass cache: "bounded" or configure their cache in a manner that isn't unbounded (which is current default behavior). This protects your server from attacks that exhaust available memory, causing a DOS. 

This commit applies the recommended fix in the Apollo Server [docs](https://www.apollographql.com/docs/apollo-server/v3/performance/cache-backends/#ensuring-a-bounded-cache) by passing a `cache: bounded` option to the `ApolloServer` constructor.